### PR TITLE
Add support for cargo features and running cargo build with --verbose

### DIFF
--- a/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
@@ -66,6 +66,10 @@ open class CargoBuildTask : DefaultTask() {
 
                 val theCommandLine = mutableListOf("cargo", "build");
 
+                if (cargoExtension.verbose) {
+                    theCommandLine.add("--verbose")
+                }
+
                 if (cargoExtension.allFeatures) {
                     if (cargoExtension.features != null) {
                         throw GradleException("Cannot specify `allFeatures` with `features`!")

--- a/plugin/src/main/kotlin/com/nishtahir/CargoExtension.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoExtension.kt
@@ -81,4 +81,9 @@ open class CargoExtension {
     * `defaultFeatures = false`.
      */
     var allFeatures: Boolean = false
+
+    /**
+     * Set to true to execute `cargo build` with the `--verbose` flag
+     */
+    var verbose: Boolean = false
 }

--- a/plugin/src/main/kotlin/com/nishtahir/CargoExtension.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoExtension.kt
@@ -55,4 +55,30 @@ open class CargoExtension {
     // and Kotlin that are just not worth working out.  Another JVM language, yet another dynamic
     // invoke solution :(
     var exec: ((ExecSpec, Toolchain) -> Unit)? = null
+
+    /**
+     * List of cargo features to use to build the library. These are passed as
+     * a space separated string to cargo with `--features`.
+     *
+     * It's an error to use this with `allFeatures = true`.
+     */
+    var features: Array<String>? = null
+
+    /**
+     * Whether or not the project's default features should be included.
+     * Defaults to true. Setting this to false is equivalent to passing
+     * `--no-default-features` to cargo build.
+     *
+     * It's an error to set this to `false` when using `allFeatures = true`.
+     */
+    var defaultFeatures: Boolean = true
+
+    /**
+     * Setting this to true is equivalent to passing `--all-features` to `cargo
+     * build`.
+     *
+     * It's an error to use this with a list of `features` or when
+    * `defaultFeatures = false`.
+     */
+    var allFeatures: Boolean = false
 }

--- a/samples/library/build.gradle
+++ b/samples/library/build.gradle
@@ -46,6 +46,7 @@ cargo {
 
     features = ["foo", "bar"]
     defaultFeatures = false
+    verbose = true
 
     exec = { spec, toolchain ->
         spec.environment("TEST", "test")

--- a/samples/library/build.gradle
+++ b/samples/library/build.gradle
@@ -44,6 +44,9 @@ cargo {
     module = "../rust"
     targets = ["arm", "arm64", "x86"]
 
+    features = ["foo", "bar"]
+    defaultFeatures = false
+
     exec = { spec, toolchain ->
         spec.environment("TEST", "test")
     }

--- a/samples/rust/Cargo.toml
+++ b/samples/rust/Cargo.toml
@@ -11,3 +11,9 @@ tokio-core = "0.1"
 
 [lib]
 crate_type = ["staticlib", "dylib"]
+
+[features]
+default = ["foo"]
+foo = []
+bar = []
+


### PR DESCRIPTION
The `--verbose` support was mainly so I could debug this, but I could see it helping in debugging build issues in e.g. application-services as well.