### PR TITLE
Use Travis-CI to test against multiple versions of Android.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+sudo: required
+dist: precise
+language: android
+
+jdk:
+  - openjdk8
+
+android:
+  components:
+    - tools
+    - platform-tools
+
+env:
+  matrix:
+    - API=android-21 ABI=x86
+    # - API=android-22 ABI=x86
+    # - API=android-23 ABI=x86
+    # - API=android-24 ABI=x86
+    # - API=android-25 ABI=x86
+    # - API=android-26 ABI=x86
+    # - API=android-27 ABI=x86
+    - API=android-28 ABI=x86
+
+# Emulator Management: Create, Start and Wait
+before_script:
+  - android-update-sdk --components=sys-img-$ABI-$API --accept-licenses='android-sdk-license-[0-9a-f]{8}'
+  - echo no | android create avd --force -n test -t $API --abi $ABI
+  - emulator -avd test -no-audio -no-window
+  - android-wait-for-emulator
+  - adb shell input keyevent 82 &
+
+script:
+- ./gradlew clean assemble

--- a/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
@@ -62,7 +62,12 @@ open class CargoBuildTask : DefaultTask() {
 
             with(spec) {
                 standardOutput = System.out
-                workingDir = File(project.project.projectDir, cargoExtension.module)
+
+                if (!File(cargoExtension.module).isAbsolute()) {
+                    workingDir = File(project.project.projectDir, cargoExtension.module)
+                } else {
+                    workingDir = File(cargoExtension.module)
+                }
 
                 val theCommandLine = mutableListOf("cargo", "build");
 


### PR DESCRIPTION
We want to support Android 21 through 28.  We're hoping to avoid issues like https://github.com/mozilla/application-services/issues/197.