### PR TITLE
Default ANDROID_NDK_TOOLCHAIN_DIR to temporary directory

### DIFF
--- a/plugin/src/main/kotlin/com/nishtahir/Extensions.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/Extensions.kt
@@ -14,7 +14,10 @@ fun Project.getToolchainDirectory(): File {
     val globalDir: String? = System.getenv("ANDROID_NDK_TOOLCHAIN_DIR")
     if (globalDir == null) {
         val oldDefault = File(projectDir, ".cargo/toolchain")
-        throw GradleException("Must set ANDROID_NDK_TOOLCHAIN_DIR to use rust-android-gradle plugin (previously, defaulted to ${oldDefault.absolutePath}")
+        var defaultDir = File(System.getProperty("java.io.tmpdir"), "rust-android-ndk-toolchains")
+        println("Note: previously, toolchains defaulted to ${oldDefault.absolutePath}.")
+        println("Moved to ${defaultDir.absolutePath}, or override via the ANDROID_NDK_TOOLCHAIN_DIR environment variable.")
+        return defaultDir.absoluteFile
     }
     return File(globalDir).absoluteFile
 }


### PR DESCRIPTION
This defaults the toolchain directory to `/tmp/rust-android-ndk-toolchains/` on Linux, or presumably `%TEMP%/rust-android-ndk-toolchains/` on Windows. Can test tomorrow on Windows, but I don't expect anything weird here.

If we still want the override in `local.properties`, let me know, but I actually think this is enough for now.

Fixes #7 