### PR TITLE
Windows clang needs .cmd

### DIFF
--- a/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
@@ -76,10 +76,10 @@ open class CargoBuildTask : DefaultTask() {
                 if (toolchain.target != null) {
                     theCommandLine.add("--target=${toolchain.target}")
 
-                    val cc = "${project.getToolchainDirectory()}/${toolchain.cc(apiLevel)}"
-                    val ar = "${project.getToolchainDirectory()}/${toolchain.ar(apiLevel)}"
-                    environment("CC", cc)
-                    environment("AR", ar)
+                    val cc = File(project.getToolchainDirectory(), "${toolchain.cc(apiLevel)}");
+                    val ar = File(project.getToolchainDirectory(), "${toolchain.ar(apiLevel)}");
+                    environment("CC", "$cc")
+                    environment("AR", "$ar")
 
                     // Be aware that RUSTFLAGS can have problems with embedded
                     // spaces, but that shouldn't be a problem here.

--- a/plugin/src/main/kotlin/com/nishtahir/RustAndroidPlugin.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/RustAndroidPlugin.kt
@@ -44,7 +44,11 @@ data class Toolchain(val platform: String,
                      val cc: String,
                      val ar: String,
                      val folder: String) {
-    fun cc(apiLevel: Int): String = "$platform-$apiLevel/$cc"
+    fun cc(apiLevel: Int) = if(System.getProperty("os.name").startsWith("Windows")) {
+			File("$platform-$apiLevel", "$cc.cmd")
+		} else {
+			File("$platform-$apiLevel", "$cc")
+		}
     fun ar(apiLevel: Int): String = "$platform-$apiLevel/$ar"
 }
 


### PR DESCRIPTION
Two more bugs with compiling on Windows:

a) I fixed a hard coded unix style dir separator (`/`), using Java's `File`
b) `<toolchain>-clang` is not a Windows executable. It's a `bash` script. The Windows complement is called `<toolchain>-clang.cmd`, and can be ran as a Windows executable. So we need to check on Windows vs. Unix, and select the right toolchain executable.

This PR fixes both. I can confirm I am now compiling my project on a Windows machine using this `rust-android-gradle` and `rust_swig`!